### PR TITLE
Create FixHeightOverlay.css

### DIFF
--- a/FixHeightOverlay.css
+++ b/FixHeightOverlay.css
@@ -1,0 +1,3 @@
+#jquery-overlay {
+    height: 100%;
+}


### PR DESCRIPTION
The height: 500px; on the overlay might not be suitable for all screen sizes. It's better to set the height to 100% to cover the entire viewport.